### PR TITLE
优化 install.bat 的结束流程

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -88,8 +88,9 @@ if %sub%==Nor (
     echo set rdpwrap_ini_update_github_5="https://raw.githubusercontent.com/saurav-biswas/rdpwrap-1/master/res/rdpwrap.ini">>"%spath%\subscription.bat"
 )
 echo [*] 安装已完成
-explorer "%spath%"
-echo 请点击autoupdate.bat以更新版本支持。
+echo 请在之后出现的文件夹窗口中点击autoupdate.bat以更新版本支持。
 echo 在更新完配置文件后请点击RDPConf.exe中的Apply以启动。
 echo 如果能在RDPCheck.exe中登陆，则已成功。
 echo 你可以在Setting.bat中配置自动更新选项和修复选项
+pause
+explorer "%spath%"


### PR DESCRIPTION
本PR优化了 install.bat 文件的结束过程，具体描述如下：

原先的 install.bat 文件在完成后会直接退出，用户来不及查看安装完成后的提示。
本PR添加了 `pause` 指令，并且将 `explorer "%spath%"` 指令移至文件最后，以便于用户查看安装完成后的提示